### PR TITLE
Adding OracleServerAccessSecurityGroup to the outputs section.

### DIFF
--- a/templates/oracle-database.template
+++ b/templates/oracle-database.template
@@ -3019,6 +3019,12 @@
                 "Ref": "KeyPairName"
             },
             "Description": "Key pair for the instances"
+        },
+        "OracleServerAccessSecurityGroup": {
+            "Value": {
+                "Ref": "OracleServerAccessSecurityGroup"
+            },
+            "Description": "Security group that gives access to Oracle databases"
         }
     }
 }


### PR DESCRIPTION
In order for other QuickStarts to use this template as a submodule, the Oracle QS needs to output the ID of the security group it creates for upstream application servers to attach to.