### PR TITLE
pystache downgrade for both Primary and Standby instance UserData

### DIFF
--- a/templates/oracle-database-master.template.yaml
+++ b/templates/oracle-database-master.template.yaml
@@ -383,7 +383,7 @@ Parameters:
       - Red-Hat-Enterprise-Linux-7.2-HVM
       - Oracle-Linux-7.3-HVM
     Default: Red-Hat-Enterprise-Linux-7.2-HVM
-    Description: Operating system and version for master/worker nodes.
+    Description: Operating system and version for main/worker nodes.
     Type: String
   OracleInstanceType:
     AllowedValues:

--- a/templates/oracle-database.template.yaml
+++ b/templates/oracle-database.template.yaml
@@ -669,8 +669,8 @@ Resources:
   InstanceRoleOrcl:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns: !Sub
-        - arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM
       Policies:
         - PolicyDocument:
             Version: '2012-10-17'
@@ -702,8 +702,8 @@ Resources:
                     - logs:CreateLogStream
                     - logs:PutLogEvents
                     - logs:DescribeLogStreams
-                  Resource: !Sub 
-                    - arn:${AWS::Partition}:logs:*:*:*
+                  Resource:
+                    - !Sub arn:${AWS::Partition}:logs:*:*:*
             PolicyName: aws-quick-start-cloudwatchlogs-policy
           - !Ref 'AWS::NoValue'
       Path: /

--- a/templates/oracle-database.template.yaml
+++ b/templates/oracle-database.template.yaml
@@ -669,8 +669,8 @@ Resources:
   InstanceRoleOrcl:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+      ManagedPolicyArns: !Sub
+        - arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM
       Policies:
         - PolicyDocument:
             Version: '2012-10-17'
@@ -702,8 +702,8 @@ Resources:
                     - logs:CreateLogStream
                     - logs:PutLogEvents
                     - logs:DescribeLogStreams
-                  Resource:
-                    - arn:aws:logs:*:*:*
+                  Resource: !Sub 
+                    - arn:${AWS::Partition}:logs:*:*:*
             PolicyName: aws-quick-start-cloudwatchlogs-policy
           - !Ref 'AWS::NoValue'
       Path: /

--- a/templates/oracle-database.template.yaml
+++ b/templates/oracle-database.template.yaml
@@ -1111,6 +1111,7 @@ Resources:
             - "echo '[Update Operating System]'\n"
             - "qs_update-os || qs_error\n"
             - "qs_bootstrap_pip || qs_error\n"
+            - "pip install pystache==0.5.4\n"
             - "qs_aws-cfn-bootstrap || qs_error\n"
             - !If
               - CWL

--- a/templates/oracle-database.template.yaml
+++ b/templates/oracle-database.template.yaml
@@ -1625,6 +1625,7 @@ Resources:
             - "echo '[Update Operating System]'\n"
             - "qs_update-os || qs_error\n"
             - "qs_bootstrap_pip || qs_error\n"
+            - "pip install pystache==0.5.4\n"
             - "qs_aws-cfn-bootstrap || qs_error\n"
             - !If
               - CWL


### PR DESCRIPTION
Fix for Issue #23 

I have added a pystache downgrade command into the UserData part of the CFN template, in both the PrimaryInstance and StandbyInstance resource sections.

This fixes stack deployments that use RHEL7.2 for the parameter OracleAMIOS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
